### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "author": "",
+  "repository": "spotinst/serverless-spotinst-functions",
   "license": "ISC",
   "dependencies": {
     "adm-zip": "^0.4.7",


### PR DESCRIPTION
Adds a repository field to the `package.json` file, so serverless-spotinst-functions [npm package page](https://www.npmjs.com/package/serverless-spotinst-functions) can link to the github repository.